### PR TITLE
Pick the user profile from the list tail

### DIFF
--- a/src/rebar3_docker_build.erl
+++ b/src/rebar3_docker_build.erl
@@ -70,7 +70,7 @@ format_error(Reason) ->
 
 template_parameters(RState, Config) ->
     Config#{
-        profile => hd(rebar_state:current_profiles(RState)),
+        profile => hd(lists:reverse(rebar_state:current_profiles(RState))),
         env => [#{name => N, value => escape_string(V)}
                 || {N, V} <- maps:get(env, Config)],
         git_url_rewrites => [#{from => F, to => T}


### PR DESCRIPTION
If I have different profiles in rebar3 and run 
`rebar3 as my_profile docker build` the current main only always picks up `default`.

since the rebar current_profiles returns [default, my_profile]
