### PR TITLE
Enable user to customize the base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Use
 Add the plugin to your rebar config:
 
     {plugins, [
-        {rebar3_docker, {git, "https://github.com/stritzinger/rebar3_docker.git", {tag, "0.1.0"}}}
+        {rebar3_docker, {git, "https://github.com/stritzinger/rebar3_docker.git", {branch, "main"}}}
     ]}.
 
 Add docker the configuration as needed to your rebar config:
@@ -26,9 +26,14 @@ Add docker the configuration as needed to your rebar config:
         % If not specified, uses "locale/release_name".
         {tag, "local/somename"},
         % The version of the erlang docker image.
-        % If not specified, uses "25.1.2.0"
-        {erlang_version, "25.1.2.0"},
-        % The name of the applicattion release.
+        % If not specified, uses "25.3.2.2"
+        {erlang_version, "25.3.2.2"},
+        % If you need to further customize the building environment,
+        % this option overrides the official erlang image with anything you want.
+        % in this case the erlang_version option is ignored 
+        % Must still be an alpine based image and contain OTP + Rebar3!
+        % {builder_image, "your-repo/your-image:tag"},
+        % The name of the application release.
         % If not specified use the first release name found in the relx config.
         {appname, "appname"},
         % The extra packages to install in the building docker layer.

--- a/priv/templates/Dockerfile
+++ b/priv/templates/Dockerfile
@@ -3,8 +3,7 @@
 #--- Builder -------------------------------------------------------------------
 
 ARG profile={{profile}}
-ARG erlang_version={{erlang_version}}
-FROM erlang:$erlang_version-alpine as builder
+FROM {{builder_image}} as builder
 
 WORKDIR /app/src
 ENV REBAR_BASE_DIR /app/_build

--- a/src/rebar3_docker_util.erl
+++ b/src/rebar3_docker_util.erl
@@ -10,10 +10,11 @@
 
 %%% MACROS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--define(DEFAULT_ERLANG_VERSION, <<"25.1.2.0">>).
+-define(DEFAULT_ERLANG_VERSION, <<"25.3.2.2">>).
 -define(CONFIG_KEYS, [
         {tag, binary},
         {erlang_version, binary},
+        {builder_image, binary},
         {appname, binary},
         {build_packages, [list, binary]},
         {git_url_rewrites, [list, [tuple, [binary, binary]]]},
@@ -26,7 +27,8 @@
 %%% API FUNCTIONS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 config(RState) ->
-    maps:merge(default_config(RState), docker_config(RState)).
+    UserCfg = maps:merge(default_config(RState), docker_config(RState)),
+    define_builder_image(UserCfg).
 
 container_dir(RState) ->
     filename:join([rebar_state:dir(RState),
@@ -35,6 +37,10 @@ container_dir(RState) ->
                    "container"]).
 
 %%% INTERNAL FUNCTIONS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+define_builder_image(#{builder_image := _} = Cfg) -> Cfg;
+define_builder_image(#{erlang_version := ErlV} = Cfg) ->
+    Cfg#{builder_image => "erlang:" ++ ErlV ++ "-alpine" }.
 
 release_config(RState) ->
     Config =  rebar_state:get(RState, relx, []),


### PR DESCRIPTION
We need this internally to specify a custom docker image containing a modified OTP build.
This is completely optional for the user and just adds more freedom.