### PR TITLE
Gl/multi platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Add docker the configuration as needed to your rebar config:
         {env, [
             {'COOKIE', "dummy"},
             {'LOGGER_LEVEL', debug}
-        ]}
+        ]},
         % The target platform for the build output
         % You can specify multiple platform if your docker configuration allows it
         % If not specified, then the flag isn't used when building the docker image

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Add docker the configuration as needed to your rebar config:
             {'COOKIE', "dummy"},
             {'LOGGER_LEVEL', debug}
         ]}
+        % The target platform for the build output
+        % You can specify multiple platform if your docker configuration allows it
+        % If not specified, then the flag isn't used when building the docker image
+        {platform, ["linux/arm64"]}
     ]}
 
 Be sure to configure a relx release and then just call the plugin build command:

--- a/src/rebar3_docker_util.erl
+++ b/src/rebar3_docker_util.erl
@@ -20,7 +20,8 @@
         {git_url_rewrites, [list, [tuple, [binary, binary]]]},
         {runtime_packages, [list, binary]},
         {ports, [list, [tuple, [integer, {tcp, udp}]]]},
-        {env, [list, [tuple, [binary, any]]]}
+        {env, [list, [tuple, [binary, any]]]},
+        {platform, [list, binary]}
 ]).
 
 
@@ -101,5 +102,6 @@ default_config(RState) ->
         git_url_rewrites => [],
         ports => [],
         build_packages => [],
-        runtime_packages => []
+        runtime_packages => [],
+        platform => []
     }.


### PR DESCRIPTION
This PR adds the option `--platform` of the command `docker build` inside the `rebar.config` file.

For example:
```
{docker, [
    {ports, [{1234, tcp}]},
    {env, [
        {'COOKIE', "dummy"},
        {'LOGGER_LEVEL', debug}
    ]},
    {platform, ["linux/arm64"]}
]}.
```
The list format indicates that we also support multiple target architecture. However, this requires a special docker setup described [here](https://docs.docker.com/build/building/multi-platform/)