### PR TITLE
Bump default OTP version to 28 and improve README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Default OTP builder version updated from `25.3.2.2` to `28.4.0.0`.
+* README now documents the intended `include_erts = true` release model and the OTP upgrade path.
+
 ## [0.2.0] - 2024-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,117 +1,213 @@
 rebar3_docker
 =====
 
-A simple rebar plugin to build docker containers out of an Erlang release.
+A simple rebar plugin to build Docker images from an Erlang release.
 
 
 Build
 -----
 
-    $ rebar3 compile
+```sh
+rebar3 compile
+```
 
 
 Use
 ---
 
-Add the plugin to your rebar config:
+Add the plugin to your `rebar.config`:
 
-    {plugins, [
-        rebar3_docker
-    ]}.
+```erlang
+{plugins, [
+    rebar3_docker
+]}.
+```
 
-Add docker the configuration as needed to your rebar config:
+Then configure the Docker build:
 
-    {docker, [
-        % The tag to be used to publish the docker image.
-        % If not specified, uses "locale/release_name".
-        {tag, "local/somename"},
-        % The version of the erlang docker image.
-        % If not specified, uses "25.3.2.2"
-        {erlang_version, "25.3.2.2"},
-        % If you need to further customize the building environment,
-        % this option overrides the official erlang image with anything you want.
-        % in this case the erlang_version option is ignored 
-        % Must still be an alpine based image and contain OTP + Rebar3!
-        % {builder_image, "your-repo/your-image:tag"},
-        % The name of the application release.
-        % If not specified use the first release name found in the relx config.
-        {appname, "appname"},
-        % The extra packages to install in the building docker layer.
-        {build_packages, [            % 
-            make,
-            gcc,
-            "libc-dev",
-            "libbsd-dev"
-        ]},
-        % The git url to be rewritten. Used to access private repository.
-        {git_url_rewrites, [
-            {"https://github.com/", "git@github.com:"}
-        ]},
-        % The extra runtime package to install in the final docker image.
-        {runtime_packages, []},
-        % The ports to be exposed by the docker image.
-        {ports, [
-            {8888, tcp}
-        ]},
-        % The docker image environment.
-        {env, [
-            {'COOKIE', "dummy"},
-            {'LOGGER_LEVEL', debug}
-        ]},
-        % The target platform for the build output
-        % You can specify multiple platform if your docker configuration allows it
-        % If not specified, then the flag isn't used when building the docker image
-        {platform, ["linux/arm64"]}
+```erlang
+{docker, [
+    % The tag used when publishing the Docker image.
+    % If not specified, defaults to "local/<release_name>".
+    {tag, "local/somename"},
+
+    % The official Erlang builder image tag, expressed as the OTP version.
+    % Defaults to "28.4.0.0", which becomes "erlang:28.4.0.0-alpine".
+    {erlang_version, "28.4.0.0"},
+
+    % Override the entire build image when you need a custom Alpine-based
+    % image that already contains OTP + Rebar3.
+    % If this is set, erlang_version is ignored.
+    % {builder_image, "your-repo/your-image:tag"},
+
+    % The name of the application release.
+    % If not specified, uses the first release name found in relx config.
+    {appname, "appname"},
+
+    % Extra Alpine packages needed while compiling the release.
+    {build_packages, [
+        make,
+        gcc,
+        "libc-dev",
+        "libbsd-dev"
+    ]},
+
+    % Git URL rewrites used while fetching dependencies.
+    {git_url_rewrites, [
+        {"https://github.com/", "git@github.com:"}
+    ]},
+
+    % Extra Alpine packages installed in the runtime image.
+    {runtime_packages, []},
+
+    % Ports exposed by the runtime image.
+    {ports, [
+        {8888, tcp}
+    ]},
+
+    % Default environment variables for the runtime image.
+    {env, [
+        {'COOKIE', "dummy"},
+        {'LOGGER_LEVEL', debug}
+    ]},
+
+    % Target platforms passed to docker build.
+    % You can specify multiple values if your Docker setup supports it.
+    {platform, ["linux/arm64"]}
+]}.
+```
+
+Be sure to configure a `relx` release and then run:
+
+```sh
+rebar3 docker build
+```
+
+
+OTP Versions
+------------
+
+This plugin builds the release in an Erlang image and runs it in a final
+Alpine image.
+
+The intended setup is to bundle ERTS into the release:
+
+```erlang
+{relx, [
+    {release, {myapp, "1.0.0"}, [myapp, sasl]},
+    {include_src, false},
+    {include_erts, true}
+]}.
+```
+
+With `{include_erts, true}`, the release carries the OTP runtime built in the
+builder stage. That means changing `erlang_version` also changes the OTP
+version used when the release starts inside the final container.
+
+This plugin assumes that model. If you do not bundle ERTS, the final image
+would need its own OTP installation, and that is intentionally not handled
+here.
+
+
+Upgrading OTP
+-------------
+
+To move from the old default `25.3.2.2` line to OTP 27 or 28, choose one of
+these approaches for the builder image.
+
+Use the official Erlang image tag:
+
+```erlang
+{docker, [
+    {erlang_version, "28.4.0.0"}
+]}.
+```
+
+That produces a builder image of `erlang:28.4.0.0-alpine`.
+
+Use your own build image:
+
+```erlang
+{docker, [
+    {builder_image, "ghcr.io/your-org/erlang-build:otp-28.4.0.0"}
+]}.
+```
+
+Notes:
+
+- `erlang_version` accepts any official Erlang tag component, so `27`,
+  `27.3`, `28`, and `28.4.0.0` all work. Pinned versions are more
+  reproducible than floating major tags.
+- `builder_image` must remain Alpine-based because the generated Dockerfile
+  installs packages with `apk`.
+- Keep `{include_erts, true}` so the runtime OTP inside the container matches
+  the OTP used to build the release.
+
+
+Example
+-------
+
+Minimal working configuration for a release exposing port `1234` and running
+on OTP 28:
+
+```erlang
+{plugins, [
+    rebar3_docker
+]}.
+
+{deps, []}.
+
+{docker, [
+    {erlang_version, "28.4.0.0"},
+    {ports, [{1234, tcp}]},
+    {env, [
+        {'COOKIE', "dummy"},
+        {'LOGGER_LEVEL', debug}
     ]}
+]}.
 
-Be sure to configure a relx release and then just call the plugin build command:
-
-    $ rebar3 docker build
-
-Example of a minimal working configuration for a release using port 1234,
-and defining logging and cookie environment variables:
-
-    {plugins, [
-        {rebar3_docker, {git, "https://github.com/stritzinger/rebar3_docker.git",
-                         {tag, "0.1.0"}}}
-    ]}.
-    {deps, []}.
-    {docker, [
-        {ports, [{1234, tcp}]},
-        {env, [
-            {'COOKIE', "dummy"},
-            {'LOGGER_LEVEL', debug}
-        ]}
-    ]}.
-    {relx, [
-        {release, {myapp, "1.0.0"}, [myapp, sasl]},
-        {include_src, false},
-        {include_erts, true}
-    ]}.
+{relx, [
+    {release, {myapp, "1.0.0"}, [myapp, sasl]},
+    {include_src, false},
+    {include_erts, true}
+]}.
+```
 
 
-STARTING A CONTAINER
+Starting A Container
 --------------------
 
-When the image as been build you can create a container and start it with:
+When the image has been built you can create a container and start it with:
 
-    docker create --name myapp local/myapp
-    docker start myapp
+```sh
+docker create --name myapp local/myapp
+docker start myapp
+```
 
 Or run it interactively in console mode:
 
-    docker run --rm -it local/myapp console
+```sh
+docker run --rm -it local/myapp console
+```
 
-If your application export some ports, you will need to explicitly publish it
-with the docker argument `-p 1234:1234`.
+If your application exposes ports, publish them explicitly with `-p`, for
+example `-p 1234:1234`.
 
 
-DEBUGGING
+Debugging
 ---------
 
-When running the build command, the docker configuration is saved in:
-    
-    _build/[PROFILE]/container/Dockerfile
+The generated Dockerfile is written to:
+
+```text
+_build/[PROFILE]/container/Dockerfile
+```
+
+That file is the easiest way to confirm which images are actually being used,
+for example:
+
+- `FROM erlang:28.4.0.0-alpine as builder`
+- `FROM alpine as runner`
 
 
 TODO

--- a/src/rebar3_docker_util.erl
+++ b/src/rebar3_docker_util.erl
@@ -10,7 +10,7 @@
 
 %%% MACROS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--define(DEFAULT_ERLANG_VERSION, <<"25.3.2.2">>).
+-define(DEFAULT_ERLANG_VERSION, <<"28.4.0.0">>).
 -define(CONFIG_KEYS, [
         {tag, binary},
         {erlang_version, binary},


### PR DESCRIPTION
## Summary
- update the default Erlang/OTP builder version from `25.3.2.2` to `28.4.0.0`
- refresh the README formatting and examples
- document the intended `{include_erts, true}` release model and OTP upgrade path

## Testing
- not run